### PR TITLE
Remove Awesome badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![Build](https://github.com/StudentSuite/awesome-ai-prompts/actions/workflows/ci.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/StudentSuite/awesome-ai-prompts?style=social)](https://github.com/StudentSuite/awesome-ai-prompts)
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)]([https://github.com/sindresorhus/awesome](https://github.com/StudentSuite/awesome-ai-prompts))
 
 A curated list of AI prompts for Student Developers. Copy-paste any prompt
 into an AI coding agent (Claude, ChatGPT, Copilot, Cursor, opencode, and


### PR DESCRIPTION
Removed the Awesome badge link from the README.

<!-- Thanks for contributing to awesome-ai-prompts. Keep PRs focused and small where possible. -->

# Pull Request

## What and why

<!-- What does this change and why? Link any related issue: Closes #123 -->

## Type

- [ ] Bug fix
- [ ] New prompt
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [ ] `bash scripts/check-links.sh` passes
- [ ] New prompts follow the repo structure (H1 title, usage note, `---` separator)
- [ ] README index updated if a prompt was added/moved
- [ ] CHANGELOG updated under `## [Unreleased]` (for user-facing changes)
- [ ] No secrets, credentials, or personal paths committed
