### PR TITLE
docs: add issue triage for maintainers prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `issue-triage-for-maintainers-prompt.md` - triage a backlog into labeled, prioritized, answerable queues
 - `csv-spreadsheet-wrangling-prompt.md` - clean messy CSV/spreadsheet exports with encoding detection, explicit type overrides, and a validation report
 - `api-design-prompt.md` - design a well-structured REST API with OpenAPI spec
 - `database-design-prompt.md` - model a relational schema from requirements

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ accountable at every step.
 
 - [Core coding](#core-coding) (10)
 - [System design](#system-design) (5)
-- [Git & GitHub](#git--github) (9)
+- [Git & GitHub](#git--github) (10)
 - [Code review & quality](#code-review--quality) (3)
 - [Testing & quality](#testing--quality) (7)
 - [Docs & delivery](#docs--delivery) (5)
@@ -97,6 +97,7 @@ accountable at every step.
 - [release-automation-prompt.md](git-github/release-automation-prompt.md) - automate versioning, tagging, changelogs, and publishing with CI.
 - [commit-checklist-prompt.md](git-github/commit-checklist-prompt.md) - build deterministic PR gates that keep indexes, changelogs, and counts in sync.
 - [pr-review-prompt.md](git-github/pr-review-prompt.md) - thorough PR review: verify claims, run checks, clear verdict, merge-ready.
+- [issue-triage-for-maintainers-prompt.md](git-github/issue-triage-for-maintainers-prompt.md) - turn an untriaged backlog into labeled, prioritized, answerable queues.
 
 ## Code review & quality
 

--- a/git-github/issue-triage-for-maintainers-prompt.md
+++ b/git-github/issue-triage-for-maintainers-prompt.md
@@ -1,0 +1,48 @@
+# Reusable prompt: issue triage for maintainers
+
+Copy-paste the block below into any AI coding agent to turn a backlog of
+untriaged issues into labeled, prioritized, answerable queues.
+
+---
+
+Triage the open issues in this repository. The goal is a backlog a
+maintainer can act on in priority order, not a pile of "looked at it" noise.
+
+## Steps
+
+1. **Check reproducibility first** - For bug reports, confirm the report
+   includes clear repro steps, expected vs actual behavior, and environment
+   details. If any are missing, reply asking for the specific missing piece
+   (name it, don't say "please provide more info") and label
+   `needs-repro`/`needs-info` rather than guessing at the cause.
+2. **Detect and link duplicates** - Search open and closed issues for the
+   same root cause before triaging as new. Link duplicates to the canonical
+   issue, summarize why they match, and close the duplicate with a pointer
+   rather than leaving both open in parallel.
+3. **Apply a severity/priority rubric consistently** - Use the repo's actual
+   label set. If none exists, propose one (e.g. `severity: blocker/high/
+   medium/low`) rather than inventing ad hoc labels per issue. Justify the
+   assigned severity in one line so the next person doesn't have to re-derive
+   it.
+4. **Flag good-first-issue candidates with mentoring notes** - When an issue
+   is small, well-scoped, and doesn't require deep repo context, label it
+   `good first issue` and add a short comment pointing to the relevant
+   file(s) or pattern to start from - this is what makes the label honest
+   instead of aspirational.
+5. **Apply stale-issue policy, don't just silently close** - If the repo has
+   a stale-bot policy, follow it. If not, propose one (e.g. ping after 60
+   days of no repro/no response, close after 14 more days) and apply it
+   consistently, always with a comment explaining why and how to reopen.
+6. **Summarize the triage pass** - Report counts by label/severity, the
+   duplicates merged, and any issues that need a maintainer decision you
+   can't make (design questions, breaking changes, roadmap calls).
+
+## Rules
+
+- Never close an issue as invalid or duplicate without linking the reasoning
+  or the canonical issue - a silent close reads as dismissive and loses
+  context for whoever revisits it.
+- Don't invent a label taxonomy that ignores one the repo already has;
+  extend it, don't fragment it.
+- Ask, don't assume, when severity or priority genuinely depends on product
+  judgment rather than technical facts.


### PR DESCRIPTION
Closes #34

Adds `git-github/issue-triage-for-maintainers-prompt.md` covering the checklist from the issue: reproducibility check with targeted needs-info replies, duplicate detection/linking, a severity/priority rubric, good-first-issue mentoring notes, and stale-issue policy.

## Test plan
- [x] `bash scripts/check-links.sh` passes clean
- [x] `bash scripts/check-consistency.sh` passes clean