### PR TITLE
docs: add responsible web scraping prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `responsible-web-scraping-prompt.md` - scrape within robots.txt/ToS, resilient selectors, checkpointed crawls
 - `csv-spreadsheet-wrangling-prompt.md` - clean messy CSV/spreadsheet exports with encoding detection, explicit type overrides, and a validation report
 - `api-design-prompt.md` - design a well-structured REST API with OpenAPI spec
 - `database-design-prompt.md` - model a relational schema from requirements

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ accountable at every step.
 - [DevOps & deploy](#devops--deploy) (9)
 - [Career & learning](#career--learning) (5)
 - [Frontend & UI](#frontend--ui) (7)
-- [Data & AI](#data--ai) (5)
+- [Data & AI](#data--ai) (6)
 
 ## Core coding
 
@@ -169,6 +169,7 @@ accountable at every step.
 - [rag-pipeline-prompt.md](data-ai/rag-pipeline-prompt.md) - build retrieval-augmented generation with citations and eval numbers before shipping.
 - [llm-feature-eval-prompt.md](data-ai/llm-feature-eval-prompt.md) - evaluate LLM features with a held-out test set and pre-committed thresholds.
 - [csv-spreadsheet-wrangling-prompt.md](data-ai/csv-spreadsheet-wrangling-prompt.md) - clean messy CSV/spreadsheet exports with encoding detection, explicit type overrides, and a validation report.
+- [responsible-web-scraping-prompt.md](data-ai/responsible-web-scraping-prompt.md) - scrape within robots.txt/ToS with resilient selectors, checkpointed crawls, and politeness budgets.
 
 ## Contributing
 

--- a/data-ai/responsible-web-scraping-prompt.md
+++ b/data-ai/responsible-web-scraping-prompt.md
@@ -1,0 +1,47 @@
+# Reusable prompt: responsible web scraping
+
+Copy-paste the block below into any AI coding agent to build a scraper that
+respects the site it's reading and survives its next layout change.
+
+---
+
+Build the requested web scraper/crawler. Scraping without guardrails gets
+IPs banned, breaks on the next redesign, and can create legal exposure;
+build it defensively from the start.
+
+## Steps
+
+1. **Respect robots.txt and ToS before writing a single request** - Fetch and
+   parse `robots.txt`, honor disallowed paths and crawl-delay directives, and
+   check the site's terms of service for an explicit scraping policy. If the
+   ToS forbids scraping, say so and stop rather than proceeding anyway.
+2. **Identify honestly** - Set a descriptive User-Agent string with contact
+   info (e.g. `myproject-bot/1.0 (+https://example.com/contact)`), not a
+   spoofed browser UA. If the site offers an API, use it instead of scraping
+   HTML.
+3. **Rate-limit and back off** - Enforce a minimum delay between requests to
+   the same host (respect `Crawl-delay` if present), add jitter, and
+   exponentially back off on 429/503 responses instead of retrying
+   immediately.
+4. **Write selectors resilient to markup drift** - Prefer stable attributes
+   (`data-*`, `id`, semantic tags) over deep positional CSS paths that break
+   on the next redesign. Add a fallback selector chain and log when the
+   primary selector misses so drift is caught early, not silently.
+5. **Make crawls incremental and resumable** - Checkpoint progress (last
+   page/ID processed) so a crash or interruption resumes instead of
+   restarting from zero. Deduplicate against already-fetched items on
+   resume.
+6. **Track politeness and error budgets** - Log requests/sec against the
+   configured limit, error rate by status code, and stop (don't keep
+   hammering) once an error budget is exceeded - that's a signal the site
+   changed or is blocking you, not a transient blip to retry through.
+
+## Rules
+
+- Never bypass a CAPTCHA, paywall, or authentication wall to scrape content
+  behind it.
+- Never scrape personal data beyond what's already public and permitted by
+  the site's policy; don't aggregate PII across sources without a stated
+  lawful basis.
+- If `robots.txt` or ToS is ambiguous or unreachable, treat that as "ask a
+  human before proceeding," not as permission by default.


### PR DESCRIPTION
Closes #21

Adds `data-ai/responsible-web-scraping-prompt.md` covering the checklist from the issue: robots.txt/ToS respect and rate limiting, honest UA identification, drift-resilient selectors, checkpointed/resumable incremental crawls, and politeness/error budgets.

## Test plan
- [x] `bash scripts/check-links.sh` passes clean
- [x] `bash scripts/check-consistency.sh` passes clean