### PR TITLE
docs: add datetime & timezone correctness prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `datetime-timezone-correctness-prompt.md` - UTC storage, DST handling, safe parsing, calendar/duration math
 - `csv-spreadsheet-wrangling-prompt.md` - clean messy CSV/spreadsheet exports with encoding detection, explicit type overrides, and a validation report
 - `api-design-prompt.md` - design a well-structured REST API with OpenAPI spec
 - `database-design-prompt.md` - model a relational schema from requirements

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ accountable at every step.
 
 ## Contents
 
-- [Core coding](#core-coding) (10)
+- [Core coding](#core-coding) (11)
 - [System design](#system-design) (5)
 - [Git & GitHub](#git--github) (9)
 - [Code review & quality](#code-review--quality) (3)
@@ -77,6 +77,7 @@ accountable at every step.
 - [database-design-prompt.md](core-coding/database-design-prompt.md) - model a relational schema from requirements with normalization, indexes, and migration path.
 - [environment-setup-prompt.md](core-coding/environment-setup-prompt.md) - bootstrap a dev environment from scratch: deps, tooling, config, first-run verification.
 - [code-migration-prompt.md](core-coding/code-migration-prompt.md) **[spec]** - migrate code between frameworks/languages with behavior parity and incremental verification.
+- [datetime-timezone-correctness-prompt.md](core-coding/datetime-timezone-correctness-prompt.md) - store UTC render local, handle DST, and get calendar/duration math right.
 
 ## System design
 

--- a/core-coding/datetime-timezone-correctness-prompt.md
+++ b/core-coding/datetime-timezone-correctness-prompt.md
@@ -1,0 +1,50 @@
+# Reusable prompt: datetime & timezone correctness
+
+Copy-paste the block below into any AI coding agent to handle dates and
+times correctly instead of shipping the timezone bug that only shows up in
+production, months later.
+
+---
+
+Review or implement the datetime handling in this task. Timezone bugs are
+among the most common production defects and are almost never caught by a
+"looks right on my machine" check; treat every date/time value as a trap
+until proven otherwise.
+
+## Steps
+
+1. **Store UTC, render local, always** - Persist and pass around timestamps
+   in UTC (or a fixed offset like Unix epoch millis); convert to the user's
+   local timezone only at the display/render boundary. Never store a
+   "local" timestamp without its offset.
+2. **Handle DST transitions explicitly** - Identify any logic that adds
+   durations to a local time (e.g. "add 1 day") and confirm it survives a
+   spring-forward/fall-back transition; use timezone-aware date-math
+   libraries rather than naive arithmetic on wall-clock time. Flag
+   ambiguous local times (the repeated hour during fall-back) instead of
+   picking one silently.
+3. **Parse untrusted date input defensively** - Never trust an
+   unconstrained free-text date format from users or external APIs; validate
+   against expected formats, reject or explicitly flag ambiguous inputs
+   (e.g. `01/02/2026`, day-first vs month-first), and record the assumed
+   timezone when the input doesn't specify one.
+4. **Get durations and calendar math right** - Distinguish elapsed duration
+   (a fixed number of seconds) from calendar duration ("add 1 month", which
+   varies in length); use business-day math (skipping weekends/holidays)
+   only where explicitly required, and state which holiday calendar applies.
+5. **Write property tests around clock changes** - Test date-math functions
+   across a DST boundary, a leap year/leap second edge, a month-end rollover
+   (Jan 31 + 1 month), and a UTC offset that isn't a whole hour (e.g.
+   India's UTC+5:30) - these are exactly the cases naive implementations get
+   wrong.
+
+## Rules
+
+- Never format or compare a "naive" datetime (no timezone attached) against
+  a timezone-aware one; make the mismatch a type error where the language
+  allows it.
+- Never hardcode a specific timezone offset as a constant; timezones and
+  their offsets change (DST rules, political redefinitions) - use a
+  timezone database, not a fixed number.
+- If a date's true intended timezone is ambiguous from context, ask or
+  document the assumption instead of guessing UTC vs local silently.


### PR DESCRIPTION
Closes #4

Adds `core-coding/datetime-timezone-correctness-prompt.md` covering the checklist from the issue: store UTC/render local, explicit DST transition handling, safe parsing of untrusted date input, calendar vs elapsed duration math, and property tests around clock changes.

## Test plan
- [x] `bash scripts/check-links.sh` passes clean
- [x] `bash scripts/check-consistency.sh` passes clean